### PR TITLE
Use types and structure for pieces and squares

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -1,176 +1,153 @@
-#![allow(dead_code)]
-pub use crate::engine::*;
-pub use crate::utils::*;
+use crate::engine::*;
+use crate::utils::*;
 use colored::*;
+use std::fmt;
+use std::str::FromStr;
 
 // Board position for the start of a new game
 pub const DEFAULT_FEN_STRING: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
-/*
-    Example Piece: 0b10000101 = WHITE | QUEEN
-    1st bit: Color 1 = White, 0 = Black
-    2-5 bit: Unused
-    6-8 bit: Piece identifier
-*/
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Square {
+    /// This square is empty.
+    Empty,
 
-pub const COLOR_MASK: u8 = 0b10000000;
-pub const WHITE: u8 = 0b10000000;
-pub const BLACK: u8 = 0b00000000;
+    /// A piece is on this square
+    Full(Piece),
 
-pub const PIECE_MASK: u8 = 0b00000111;
-pub const PAWN: u8 = 0b00000001;
-pub const KNIGHT: u8 = 0b00000010;
-pub const BISHOP: u8 = 0b00000011;
-pub const ROOK: u8 = 0b00000100;
-pub const QUEEN: u8 = 0b00000101;
-pub const KING: u8 = 0b00000110;
-
-pub const EMPTY: u8 = 0;
-pub const SENTINEL: u8 = 0b11111111;
-
-pub const BOARD_START: usize = 2;
-pub const BOARD_END: usize = 10;
-
-type Point = (usize, usize);
-
-pub fn get_color(square: u8) -> Option<PieceColor> {
-    if is_empty(square) || is_outside_board(square) {
-        return None;
-    }
-    if square & COLOR_MASK == WHITE {
-        return Some(PieceColor::White);
-    }
-    Some(PieceColor::Black)
+    /// A non-board square; the board data structure contains squares not present on the
+    /// actual board in order to make move calculation easier, and all such squares have
+    /// this variant.
+    Invalid,
 }
 
-pub fn is_white(square: u8) -> bool {
-    !is_empty(square) && square & COLOR_MASK == WHITE
-}
-
-pub fn is_black(square: u8) -> bool {
-    !is_empty(square) && square & COLOR_MASK == BLACK
-}
-
-pub fn is_pawn(square: u8) -> bool {
-    square & PIECE_MASK == PAWN
-}
-
-pub fn is_knight(square: u8) -> bool {
-    square & PIECE_MASK == KNIGHT
-}
-
-pub fn is_bishop(square: u8) -> bool {
-    square & PIECE_MASK == BISHOP
-}
-
-pub fn is_rook(square: u8) -> bool {
-    square & PIECE_MASK == ROOK
-}
-
-pub fn is_queen(square: u8) -> bool {
-    square & PIECE_MASK == QUEEN
-}
-
-pub fn is_king(square: u8) -> bool {
-    square & PIECE_MASK == KING
-}
-
-pub fn is_empty(square: u8) -> bool {
-    square == EMPTY
-}
-
-pub fn is_outside_board(square: u8) -> bool {
-    square == SENTINEL
-}
-
-/*
-    Returns the row, col on the board when given the algebraic coordinates
-*/
-pub fn algebraic_pairs_to_board_position(pair: &str) -> Option<Point> {
-    if pair.len() != 2 {
-        return None;
+impl Square {
+    /// Check if this square is empty or contains a piece of the given color (used in move
+    /// generation)
+    pub fn is_empty_or_color(&self, color: PieceColor) -> bool {
+        match self {
+            Square::Empty => true,
+            Square::Full(Piece {
+                color: square_color,
+                ..
+            }) => color == *square_color,
+            _ => false,
+        }
     }
 
-    let c = pair.chars().nth(0).unwrap();
-    let r = pair.chars().nth(1).unwrap();
-    let col = match c {
-        'a' => 0,
-        'b' => 1,
-        'c' => 2,
-        'd' => 3,
-        'e' => 4,
-        'f' => 5,
-        'g' => 6,
-        'h' => 7,
-        _ => return None,
-    };
-
-    let row = BOARD_END - (r.to_digit(10).unwrap() as usize);
-    if !(BOARD_START..BOARD_END).contains(&row) {
-        return None;
+    /// Check if this square is empty
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Square::Empty)
     }
 
-    Some((row, col + BOARD_START))
-}
-
-pub fn board_position_to_algebraic_pair(pair: Point) -> String {
-    let row = match pair.0 {
-        2 => "8",
-        3 => "7",
-        4 => "6",
-        5 => "5",
-        6 => "4",
-        7 => "3",
-        8 => "2",
-        9 => "1",
-        _ => "1",
-    };
-    let col = match pair.1 {
-        2 => "a",
-        3 => "b",
-        4 => "c",
-        5 => "d",
-        6 => "e",
-        7 => "f",
-        8 => "g",
-        9 => "h",
-        _ => "h",
-    };
-    col.to_string() + &row.to_string()
-}
-
-fn get_piece_character(piece: u8) -> &'static str {
-    match piece & PIECE_MASK {
-        PAWN => "♟︎",
-        KNIGHT => "♞",
-        BISHOP => "♝",
-        ROOK => "♜",
-        QUEEN => "♛",
-        KING => "♚",
-        _ => " ",
+    /// Check if this square is valid (invalid squares are used to make move generation easier)
+    pub fn is_valid(&self) -> bool {
+        !matches!(self, Square::Invalid)
     }
-}
 
-fn get_piece_character_simple(piece: u8) -> &'static str {
-    if is_white(piece) {
-        match piece & PIECE_MASK {
-            PAWN => "P",
-            KNIGHT => "N",
-            BISHOP => "B",
-            ROOK => "R",
-            QUEEN => "Q",
-            KING => "K",
+    /// Get the "fancy" character to reporesent the content of this square
+    fn fancy_char(&self) -> &'static str {
+        match self {
+            Square::Full(piece) => piece.fancy_char(),
             _ => " ",
         }
-    } else {
-        match piece & PIECE_MASK {
-            PAWN => "p",
-            KNIGHT => "n",
-            BISHOP => "b",
-            ROOK => "r",
-            QUEEN => "q",
-            KING => "k",
+    }
+
+    /// Get the "simple" character to represent this content of this square (capitalized based on
+    /// the piece's color)
+    fn simple_char(&self) -> &'static str {
+        match self {
+            Square::Full(piece) => piece.simple_char(),
             _ => " ",
+        }
+    }
+}
+
+impl From<Piece> for Square {
+    /// Given a piece, generate a square containing that piece
+    fn from(piece: Piece) -> Self {
+        Square::Full(piece)
+    }
+}
+
+impl PartialEq<Piece> for Square {
+    fn eq(&self, other: &Piece) -> bool {
+        match self {
+            Square::Full(piece) => piece == other,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct Piece {
+    pub color: PieceColor,
+    pub kind: PieceKind,
+}
+
+impl Piece {
+    /// Get the value of this piece
+    pub fn value(&self) -> i32 {
+        self.kind.value()
+    }
+
+    pub const fn pawn(color: PieceColor) -> Self {
+        Self { kind: Pawn, color }
+    }
+
+    pub const fn knight(color: PieceColor) -> Self {
+        Self {
+            kind: Knight,
+            color,
+        }
+    }
+
+    pub const fn bishop(color: PieceColor) -> Self {
+        Self {
+            kind: Bishop,
+            color,
+        }
+    }
+
+    pub const fn rook(color: PieceColor) -> Self {
+        Self { kind: Rook, color }
+    }
+
+    pub const fn queen(color: PieceColor) -> Self {
+        Self { kind: Queen, color }
+    }
+
+    pub const fn king(color: PieceColor) -> Self {
+        Self { kind: King, color }
+    }
+
+    /// Get the "fancy" character for this piece
+    fn fancy_char(&self) -> &'static str {
+        match self.kind {
+            Pawn => "♟︎",
+            Knight => "♞",
+            Bishop => "♝",
+            Rook => "♜",
+            Queen => "♛",
+            King => "♚",
+        }
+    }
+
+    /// Get the "simple" character to represent this piece (capitalized based on the piece's color)
+    fn simple_char(&self) -> &'static str {
+        match (self.color, self.kind) {
+            (White, Pawn) => "P",
+            (White, Knight) => "N",
+            (White, Bishop) => "B",
+            (White, Rook) => "R",
+            (White, Queen) => "Q",
+            (White, King) => "K",
+            (Black, Pawn) => "p",
+            (Black, Knight) => "n",
+            (Black, Bishop) => "b",
+            (Black, Rook) => "r",
+            (Black, Queen) => "q",
+            (Black, King) => "k",
         }
     }
 }
@@ -182,11 +159,117 @@ pub enum PieceColor {
 }
 
 impl PieceColor {
-    pub fn as_mask(&self) -> u8 {
-        match *self {
-            PieceColor::White => WHITE,
-            PieceColor::Black => BLACK,
+    /// Get the opposite color
+    pub fn opposite(&self) -> Self {
+        match self {
+            Black => White,
+            White => Black,
         }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum PieceKind {
+    Pawn,
+    Knight,
+    Bishop,
+    Rook,
+    Queen,
+    King,
+}
+
+impl PieceKind {
+    /// Get the value of this kind of piece
+    pub fn value(&self) -> i32 {
+        match self {
+            Pawn => 100,
+            Knight => 320,
+            Bishop => 330,
+            Rook => 500,
+            Queen => 900,
+            King => 20000,
+        }
+    }
+
+    /// Get the alg name for this kind of piece
+    pub fn alg(&self) -> &'static str {
+        match self {
+            Pawn => "p",
+            Knight => "n",
+            Bishop => "b",
+            Rook => "r",
+            Queen => "q",
+            King => "k",
+        }
+    }
+}
+
+pub const BOARD_START: usize = 2;
+pub const BOARD_END: usize = 10;
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct Point(pub usize, pub usize);
+
+impl FromStr for Point {
+    type Err = &'static str;
+
+    /// Parse an algebraic pair into a board position
+    fn from_str(pair: &str) -> Result<Self, Self::Err> {
+        if pair.len() != 2 {
+            return Err("Invalid length for algebraic string");
+        }
+
+        let c = pair.chars().nth(0).unwrap();
+        let r = pair.chars().nth(1).unwrap();
+        let col = match c {
+            'a' => 0,
+            'b' => 1,
+            'c' => 2,
+            'd' => 3,
+            'e' => 4,
+            'f' => 5,
+            'g' => 6,
+            'h' => 7,
+            _ => return Err("Invalid column"),
+        };
+
+        let row = BOARD_END - (r.to_digit(10).unwrap() as usize);
+        if !(BOARD_START..BOARD_END).contains(&row) {
+            return Err("Invalid row");
+        }
+
+        Ok(Point(row, col + BOARD_START))
+    }
+}
+
+impl fmt::Display for Point {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}{}",
+            match self.1 {
+                2 => "a",
+                3 => "b",
+                4 => "c",
+                5 => "d",
+                6 => "e",
+                7 => "f",
+                8 => "g",
+                9 => "h",
+                _ => "h",
+            },
+            match self.0 {
+                2 => "8",
+                3 => "7",
+                4 => "6",
+                5 => "5",
+                6 => "4",
+                7 => "3",
+                8 => "2",
+                9 => "1",
+                _ => "1",
+            },
+        )
     }
 }
 
@@ -194,7 +277,7 @@ impl PieceColor {
 pub struct BoardState {
     pub full_move_clock: u8, // The number of the full moves. It starts at 1, and is incremented after Black's move
     pub half_move_clock: u8, // The number of half moves since the last capture or pawn advance, used for the fifty-move rule
-    pub board: [[u8; 12]; 12],
+    pub board: [[Square; 12]; 12],
     pub to_move: PieceColor,
     // if a pawn, on the last move, made a double move, this is set, otherwise this is None
     pub pawn_double_move: Option<Point>,
@@ -210,22 +293,186 @@ pub struct BoardState {
 }
 
 impl BoardState {
+    /// Parse the standard fen string notation (en.wikipedia.org/wiki/Forsyth–Edwards_Notation) and return a board state
+    pub fn from_fen(fen: &str) -> Result<BoardState, &str> {
+        let mut board = [[Square::Invalid; 12]; 12];
+        let mut fen = fen.to_string();
+        trim_newline(&mut fen);
+        let fen_config: Vec<&str> = fen.split(' ').collect();
+        if fen_config.len() != 6 {
+            return Err("Could not parse fen string: Invalid fen string");
+        }
+
+        let to_move = match fen_config[1] {
+            "w" => PieceColor::White,
+            "b" => PieceColor::Black,
+            _ => return Err("Could not parse fen string: Next player to move was not provided"),
+        };
+        let castling_privileges = fen_config[2];
+        let en_passant = fen_config[3];
+
+        let half_move_clock = fen_config[4].parse::<u8>();
+        if half_move_clock.is_err() {
+            return Err("Could not parse fen string: Invalid half move value");
+        }
+
+        let full_move_clock = fen_config[5].parse::<u8>();
+        if full_move_clock.is_err() {
+            return Err("Could not parse fen string: Invalid full move value");
+        }
+
+        let fen_rows: Vec<&str> = fen_config[0].split('/').collect();
+
+        if fen_rows.len() != 8 {
+            return Err("Could not parse fen string: Invalid number of rows provided, 8 expected");
+        }
+
+        let mut row: usize = BOARD_START;
+        let mut col: usize = BOARD_START;
+        let mut white_king_location = Point(0, 0);
+        let mut black_king_location = Point(0, 0);
+        let mut white_piece_values = 0;
+        let mut black_piece_values = 0;
+        for fen_row in fen_rows {
+            for square in fen_row.chars() {
+                if square.is_digit(10) {
+                    let square_skip_count = square.to_digit(10).unwrap() as usize;
+                    if square_skip_count + col > BOARD_END {
+                        return Err("Could not parse fen string: Index out of bounds");
+                    }
+                    for _ in 0..square_skip_count {
+                        board[row][col] = Square::Empty;
+                        col += 1;
+                    }
+                } else {
+                    board[row][col] = match Self::piece_from_fen_string_char(square) {
+                        Some(piece) => Square::Full(piece),
+                        None => return Err("Could not parse fen string: Invalid character found"),
+                    };
+
+                    if let Square::Full(Piece { kind, color }) = board[row][col] {
+                        if color == White {
+                            white_piece_values += kind.value();
+                            if kind == King {
+                                white_king_location = Point(row, col);
+                            }
+                        } else {
+                            black_piece_values += kind.value();
+                            if kind == King {
+                                black_king_location = Point(row, col);
+                            }
+                        }
+                    }
+                    col += 1;
+                }
+            }
+            if col != BOARD_END {
+                return Err("Could not parse fen string: Complete row was not specified");
+            }
+            row += 1;
+            col = BOARD_START;
+        }
+
+        // Deal with the en passant string
+        let mut en_passant_pos: Option<Point> = None;
+        if en_passant.len() != 2 {
+            if en_passant != "-" {
+                return Err("Could not parse fen string: En passant string not valid");
+            }
+        } else {
+            en_passant_pos = en_passant.parse().ok();
+        }
+
+        Ok(BoardState {
+            full_move_clock: full_move_clock.unwrap(),
+            half_move_clock: half_move_clock.unwrap(),
+            board,
+            to_move,
+            white_king_location,
+            black_king_location,
+            pawn_double_move: en_passant_pos,
+            white_king_side_castle: castling_privileges.find('K') != None,
+            white_queen_side_castle: castling_privileges.find('Q') != None,
+            black_king_side_castle: castling_privileges.find('k') != None,
+            black_queen_side_castle: castling_privileges.find('q') != None,
+            black_total_piece_value: black_piece_values,
+            white_total_piece_value: white_piece_values,
+            last_move: None,
+        })
+    }
+
+    fn piece_from_fen_string_char(piece: char) -> Option<Piece> {
+        match piece {
+            'r' => Some(Piece {
+                color: Black,
+                kind: Rook,
+            }),
+            'n' => Some(Piece {
+                color: Black,
+                kind: Knight,
+            }),
+            'b' => Some(Piece {
+                color: Black,
+                kind: Bishop,
+            }),
+            'q' => Some(Piece {
+                color: Black,
+                kind: Queen,
+            }),
+            'k' => Some(Piece {
+                color: Black,
+                kind: King,
+            }),
+            'p' => Some(Piece {
+                color: Black,
+                kind: Pawn,
+            }),
+            'R' => Some(Piece {
+                color: White,
+                kind: Rook,
+            }),
+            'N' => Some(Piece {
+                color: White,
+                kind: Knight,
+            }),
+            'B' => Some(Piece {
+                color: White,
+                kind: Bishop,
+            }),
+            'Q' => Some(Piece {
+                color: White,
+                kind: Queen,
+            }),
+            'K' => Some(Piece {
+                color: White,
+                kind: King,
+            }),
+            'P' => Some(Piece {
+                color: White,
+                kind: Pawn,
+            }),
+            _ => None,
+        }
+    }
     pub fn pretty_print_board(&self) {
         println!("a b c d e f g h");
         for i in BOARD_START..BOARD_END {
             for j in BOARD_START..BOARD_END {
-                let piece = format!("{} ", get_piece_character(self.board[i][j]));
-                if (i + j) % 2 != 0 {
-                    if is_white(self.board[i][j]) {
-                        print!("{}", piece.white().on_truecolor(158, 93, 30));
-                    } else {
-                        print!("{}", piece.black().on_truecolor(158, 93, 30));
-                    }
-                } else if is_white(self.board[i][j]) {
-                    print!("{}", piece.white().on_truecolor(205, 170, 125));
+                let square = self.board[i][j];
+                let cell = format!("{} ", square.fancy_char());
+                let cell = match square {
+                    Square::Full(Piece { color: White, .. }) => cell.white(),
+                    Square::Full(Piece { color: Black, .. }) => cell.black(),
+                    _ => cell.white(),
+                };
+
+                let cell = if (i + j) % 2 != 0 {
+                    cell.on_truecolor(158, 93, 30)
                 } else {
-                    print!("{}", piece.black().on_truecolor(205, 170, 125));
-                }
+                    cell.on_truecolor(205, 170, 125)
+                };
+
+                print!("{}", cell);
             }
             println!(" {}", 10 - i);
         }
@@ -235,7 +482,7 @@ impl BoardState {
         let mut board = "\na b c d e f g h\n".to_string();
         for i in BOARD_START..BOARD_END {
             for j in BOARD_START..BOARD_END {
-                board = format!("{}{} ", board, get_piece_character_simple(self.board[i][j]));
+                board = format!("{}{} ", board, self.board[i][j].simple_char());
             }
             board = format!("{} {}\n", board, 10 - i);
         }
@@ -254,192 +501,53 @@ impl BoardState {
     }
 }
 
-/*
-    Parse the standard fen string notation (en.wikipedia.org/wiki/Forsyth–Edwards_Notation) and return a board state
-*/
-pub fn board_from_fen(fen: &str) -> Result<BoardState, &str> {
-    let mut board = [[SENTINEL; 12]; 12];
-    let mut fen = fen.to_string();
-    trim_newline(&mut fen);
-    let fen_config: Vec<&str> = fen.split(' ').collect();
-    if fen_config.len() != 6 {
-        return Err("Could not parse fen string: Invalid fen string");
-    }
-
-    let to_move = match fen_config[1] {
-        "w" => PieceColor::White,
-        "b" => PieceColor::Black,
-        _ => return Err("Could not parse fen string: Next player to move was not provided"),
-    };
-    let castling_privileges = fen_config[2];
-    let en_passant = fen_config[3];
-
-    let half_move_clock = fen_config[4].parse::<u8>();
-    if half_move_clock.is_err() {
-        return Err("Could not parse fen string: Invalid half move value");
-    }
-
-    let full_move_clock = fen_config[5].parse::<u8>();
-    if full_move_clock.is_err() {
-        return Err("Could not parse fen string: Invalid full move value");
-    }
-
-    let fen_rows: Vec<&str> = fen_config[0].split('/').collect();
-
-    if fen_rows.len() != 8 {
-        return Err("Could not parse fen string: Invalid number of rows provided, 8 expected");
-    }
-
-    let mut row: usize = BOARD_START;
-    let mut col: usize = BOARD_START;
-    let mut white_king_location = (0, 0);
-    let mut black_king_location = (0, 0);
-    let mut white_piece_values = 0;
-    let mut black_piece_values = 0;
-    for fen_row in fen_rows {
-        for square in fen_row.chars() {
-            if square.is_digit(10) {
-                let square_skip_count = square.to_digit(10).unwrap() as usize;
-                if square_skip_count + col > BOARD_END {
-                    return Err("Could not parse fen string: Index out of bounds");
-                }
-                for _ in 0..square_skip_count {
-                    board[row][col] = EMPTY;
-                    col += 1;
-                }
-            } else {
-                board[row][col] = match get_piece_from_fen_string_char(square) {
-                    Some(piece) => piece,
-                    None => return Err("Could not parse fen string: Invalid character found"),
-                };
-
-                if is_white(board[row][col]) {
-                    white_piece_values += PIECE_VALUES[(board[row][col] & PIECE_MASK) as usize];
-                    if is_king(board[row][col]) {
-                        white_king_location = (row, col);
-                    }
-                } else {
-                    black_piece_values += PIECE_VALUES[(board[row][col] & PIECE_MASK) as usize];
-                    if is_king(board[row][col]) {
-                        black_king_location = (row, col);
-                    }
-                }
-                col += 1;
-            }
-        }
-        if col != BOARD_END {
-            return Err("Could not parse fen string: Complete row was not specified");
-        }
-        row += 1;
-        col = BOARD_START;
-    }
-
-    // Deal with the en passant string
-    let mut en_passant_pos: Option<Point> = None;
-    if en_passant.len() != 2 {
-        if en_passant != "-" {
-            return Err("Could not parse fen string: En passant string not valid");
-        }
-    } else {
-        en_passant_pos = algebraic_pairs_to_board_position(en_passant);
-    }
-
-    Ok(BoardState {
-        full_move_clock: full_move_clock.unwrap(),
-        half_move_clock: half_move_clock.unwrap(),
-        board,
-        to_move,
-        white_king_location,
-        black_king_location,
-        pawn_double_move: en_passant_pos,
-        white_king_side_castle: castling_privileges.find('K') != None,
-        white_queen_side_castle: castling_privileges.find('Q') != None,
-        black_king_side_castle: castling_privileges.find('k') != None,
-        black_queen_side_castle: castling_privileges.find('q') != None,
-        black_total_piece_value: black_piece_values,
-        white_total_piece_value: white_piece_values,
-        last_move: None,
-    })
-}
-
-fn get_piece_from_fen_string_char(piece: char) -> Option<u8> {
-    match piece {
-        'r' => Some(BLACK | ROOK),
-        'n' => Some(BLACK | KNIGHT),
-        'b' => Some(BLACK | BISHOP),
-        'q' => Some(BLACK | QUEEN),
-        'k' => Some(BLACK | KING),
-        'p' => Some(BLACK | PAWN),
-        'R' => Some(WHITE | ROOK),
-        'N' => Some(WHITE | KNIGHT),
-        'B' => Some(WHITE | BISHOP),
-        'Q' => Some(WHITE | QUEEN),
-        'K' => Some(WHITE | KING),
-        'P' => Some(WHITE | PAWN),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     #[test]
     fn pieces_recognized() {
-        assert!(is_white(WHITE | BISHOP));
-        assert!(is_white(WHITE | ROOK));
-        assert!(is_white(WHITE | KING));
-        assert!(is_white(WHITE | PAWN));
+        assert_eq!(Piece::bishop(White).color, White);
+        assert_eq!(Piece::rook(White).color, White);
+        assert_eq!(Piece::king(White).color, White);
+        assert_eq!(Piece::pawn(White).color, White);
 
-        assert!(is_black(BLACK | BISHOP));
-        assert!(is_black(BLACK | ROOK));
-        assert!(is_black(BLACK | KING));
-        assert!(is_black(BLACK | PAWN));
+        assert_eq!(Piece::bishop(Black).color, Black);
+        assert_eq!(Piece::rook(Black).color, Black);
+        assert_eq!(Piece::king(Black).color, Black);
+        assert_eq!(Piece::pawn(Black).color, Black);
 
-        assert!(is_pawn(WHITE | PAWN));
-        assert!(is_pawn(BLACK | PAWN));
-        assert!(!is_pawn(BLACK | ROOK));
+        assert_eq!(Piece::pawn(White).kind, Pawn);
+        assert_eq!(Piece::knight(White).kind, Knight);
+        assert_eq!(Piece::bishop(White).kind, Bishop);
+        assert_eq!(Piece::rook(White).kind, Rook);
+        assert_eq!(Piece::queen(White).kind, Queen);
+        assert_eq!(Piece::king(White).kind, King);
 
-        assert!(is_knight(WHITE | KNIGHT));
-        assert!(is_knight(BLACK | KNIGHT));
-        assert!(!is_knight(WHITE | QUEEN));
+        assert!(Square::Empty.is_empty());
+        assert!(!Square::Full(Piece::king(White)).is_empty());
 
-        assert!(is_bishop(WHITE | BISHOP));
-        assert!(is_bishop(BLACK | BISHOP));
-        assert!(!is_bishop(WHITE | ROOK));
-
-        assert!(is_queen(WHITE | QUEEN));
-        assert!(is_queen(BLACK | QUEEN));
-        assert!(!is_queen(WHITE | PAWN));
-
-        assert!(is_king(WHITE | KING));
-        assert!(is_king(BLACK | KING));
-        assert!(!is_king(WHITE | QUEEN));
-
-        assert!(is_empty(EMPTY));
-        assert!(!is_empty(WHITE | KING));
-
-        assert!(is_outside_board(SENTINEL));
-        assert!(!is_outside_board(EMPTY));
-        assert!(!is_outside_board(WHITE | KING));
+        assert!(!Square::Invalid.is_valid());
+        assert!(Square::Empty.is_valid());
+        assert!(Square::Full(Piece::king(White)).is_valid());
     }
 
     // Algebraic translation tests
 
     #[test]
     fn algebraic_translation_correct() {
-        let res = algebraic_pairs_to_board_position("a8").unwrap();
+        let res = "a8".parse::<Point>().unwrap();
         assert_eq!(res.0, BOARD_START);
         assert_eq!(res.1, BOARD_START);
 
-        let res = algebraic_pairs_to_board_position("h1").unwrap();
+        let res = "h1".parse::<Point>().unwrap();
         assert_eq!(res.0, BOARD_END - 1);
         assert_eq!(res.1, BOARD_END - 1);
 
-        let res = algebraic_pairs_to_board_position("a6").unwrap();
+        let res = "a6".parse::<Point>().unwrap();
         assert_eq!(res.0, BOARD_START + 2);
         assert_eq!(res.1, BOARD_START);
 
-        let res = algebraic_pairs_to_board_position("c5").unwrap();
+        let res = "c5".parse::<Point>().unwrap();
         assert_eq!(res.0, BOARD_START + 3);
         assert_eq!(res.1, BOARD_START + 2);
     }
@@ -447,21 +555,21 @@ mod tests {
     #[test]
     #[should_panic]
     fn algebraic_translation_panic_col() {
-        algebraic_pairs_to_board_position("z1").unwrap();
+        "z1".parse::<Point>().unwrap();
     }
 
     #[test]
     #[should_panic]
     fn algebraic_translation_panic_long() {
-        algebraic_pairs_to_board_position("a11").unwrap();
+        "a11".parse::<Point>().unwrap();
     }
 
     #[test]
     fn points_to_long_algebraic_position_test() {
-        let res = board_position_to_algebraic_pair((2, 2));
+        let res = Point(2, 2).to_string();
         assert_eq!(res, "a8");
 
-        let res = board_position_to_algebraic_pair((4, 6));
+        let res = Point(4, 6).to_string();
         assert_eq!(res, "e6");
     }
 
@@ -469,47 +577,48 @@ mod tests {
 
     #[test]
     fn empty_board() {
-        let b = board_from_fen("8/8/8/8/8/8/8/8 w KQkq - 0 1").unwrap();
+        let b = BoardState::from_fen("8/8/8/8/8/8/8/8 w KQkq - 0 1").unwrap();
         for i in BOARD_START..BOARD_END {
             for j in BOARD_START..BOARD_END {
-                assert_eq!(b.board[i][j], EMPTY);
+                assert_eq!(b.board[i][j], Square::Empty);
             }
         }
     }
 
     #[test]
     fn starting_pos() {
-        let b = board_from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
-        assert_eq!(b.board[2][2], BLACK | ROOK);
-        assert_eq!(b.board[2][3], BLACK | KNIGHT);
-        assert_eq!(b.board[2][4], BLACK | BISHOP);
-        assert_eq!(b.board[2][5], BLACK | QUEEN);
-        assert_eq!(b.board[2][6], BLACK | KING);
-        assert_eq!(b.board[2][7], BLACK | BISHOP);
-        assert_eq!(b.board[2][8], BLACK | KNIGHT);
-        assert_eq!(b.board[2][9], BLACK | ROOK);
+        let b = BoardState::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+            .unwrap();
+        assert_eq!(b.board[2][2], Square::from(Piece::rook(Black)));
+        assert_eq!(b.board[2][3], Square::from(Piece::knight(Black)));
+        assert_eq!(b.board[2][4], Square::from(Piece::bishop(Black)));
+        assert_eq!(b.board[2][5], Square::from(Piece::queen(Black)));
+        assert_eq!(b.board[2][6], Square::from(Piece::king(Black)));
+        assert_eq!(b.board[2][7], Square::from(Piece::bishop(Black)));
+        assert_eq!(b.board[2][8], Square::from(Piece::knight(Black)));
+        assert_eq!(b.board[2][9], Square::from(Piece::rook(Black)));
 
         for i in BOARD_START..BOARD_END {
-            assert_eq!(b.board[3][i], BLACK | PAWN);
+            assert_eq!(b.board[3][i], Square::from(Piece::pawn(Black)));
         }
 
         for i in 4..8 {
             for j in BOARD_START..BOARD_END {
-                assert_eq!(b.board[i][j], EMPTY);
+                assert_eq!(b.board[i][j], Square::Empty);
             }
         }
 
-        assert_eq!(b.board[9][2], WHITE | ROOK);
-        assert_eq!(b.board[9][3], WHITE | KNIGHT);
-        assert_eq!(b.board[9][4], WHITE | BISHOP);
-        assert_eq!(b.board[9][5], WHITE | QUEEN);
-        assert_eq!(b.board[9][6], WHITE | KING);
-        assert_eq!(b.board[9][7], WHITE | BISHOP);
-        assert_eq!(b.board[9][8], WHITE | KNIGHT);
-        assert_eq!(b.board[9][9], WHITE | ROOK);
+        assert_eq!(b.board[9][2], Square::from(Piece::rook(White)));
+        assert_eq!(b.board[9][3], Square::from(Piece::knight(White)));
+        assert_eq!(b.board[9][4], Square::from(Piece::bishop(White)));
+        assert_eq!(b.board[9][5], Square::from(Piece::queen(White)));
+        assert_eq!(b.board[9][6], Square::from(Piece::king(White)));
+        assert_eq!(b.board[9][7], Square::from(Piece::bishop(White)));
+        assert_eq!(b.board[9][8], Square::from(Piece::knight(White)));
+        assert_eq!(b.board[9][9], Square::from(Piece::rook(White)));
 
         for i in BOARD_START..BOARD_END {
-            assert_eq!(b.board[8][i], WHITE | PAWN);
+            assert_eq!(b.board[8][i], Square::from(Piece::pawn(White)));
         }
 
         assert_eq!(
@@ -524,58 +633,63 @@ mod tests {
 
     #[test]
     fn correct_en_passant_privileges() {
-        let b =
-            board_from_fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e4 0 1").unwrap();
+        let b = BoardState::from_fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e4 0 1")
+            .unwrap();
         assert_eq!(b.pawn_double_move.unwrap().0, BOARD_START + 4);
         assert_eq!(b.pawn_double_move.unwrap().1, BOARD_START + 4);
     }
 
     #[test]
     fn correct_en_passant_privileges_black() {
-        let b =
-            board_from_fen("rnbqkbnr/ppppppp1/8/7p/8/8/PPPPPPPP/RNBQKBNR w KQkq h5 0 1").unwrap();
+        let b = BoardState::from_fen("rnbqkbnr/ppppppp1/8/7p/8/8/PPPPPPPP/RNBQKBNR w KQkq h5 0 1")
+            .unwrap();
         assert_eq!(b.pawn_double_move.unwrap().0, BOARD_START + 3);
         assert_eq!(b.pawn_double_move.unwrap().1, BOARD_START + 7);
     }
 
     #[test]
     fn correct_king_location() {
-        let b = board_from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
-        assert_eq!(b.black_king_location, (2, 6));
-        assert_eq!(b.white_king_location, (9, 6));
+        let b = BoardState::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+            .unwrap();
+        assert_eq!(b.black_king_location, Point(2, 6));
+        assert_eq!(b.white_king_location, Point(9, 6));
     }
 
     #[test]
     fn correct_king_location_two() {
-        let b = board_from_fen("6rk/1b4np/5pp1/1p6/8/1P3NP1/1B3P1P/5RK1 w KQkq - 0 1").unwrap();
-        assert_eq!(b.black_king_location, (2, 9));
-        assert_eq!(b.white_king_location, (9, 8));
+        let b =
+            BoardState::from_fen("6rk/1b4np/5pp1/1p6/8/1P3NP1/1B3P1P/5RK1 w KQkq - 0 1").unwrap();
+        assert_eq!(b.black_king_location, Point(2, 9));
+        assert_eq!(b.white_king_location, Point(9, 8));
     }
 
     #[test]
     fn correct_starting_player() {
         let mut b =
-            board_from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
+            BoardState::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+                .unwrap();
         assert_eq!(b.to_move, PieceColor::White);
-        b = board_from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1").unwrap();
+        b = BoardState::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1")
+            .unwrap();
         assert_eq!(b.to_move, PieceColor::Black);
     }
 
     #[test]
     fn correct_castling_privileges() {
-        let mut b = board_from_fen("6rk/1b4np/5pp1/1p6/8/1P3NP1/1B3P1P/5RK1 w KQkq - 0 1").unwrap();
+        let mut b =
+            BoardState::from_fen("6rk/1b4np/5pp1/1p6/8/1P3NP1/1B3P1P/5RK1 w KQkq - 0 1").unwrap();
         assert!(b.black_king_side_castle);
         assert!(b.black_queen_side_castle);
         assert!(b.white_king_side_castle);
         assert!(b.white_queen_side_castle);
 
-        b = board_from_fen("6rk/1b4np/5pp1/1p6/8/1P3NP1/1B3P1P/5RK1 w - - 0 1").unwrap();
+        b = BoardState::from_fen("6rk/1b4np/5pp1/1p6/8/1P3NP1/1B3P1P/5RK1 w - - 0 1").unwrap();
         assert!(!b.black_king_side_castle);
         assert!(!b.black_queen_side_castle);
         assert!(!b.white_king_side_castle);
         assert!(!b.white_queen_side_castle);
 
-        b = board_from_fen("6rk/1b4np/5pp1/1p6/8/1P3NP1/1B3P1P/5RK1 w Kq - 0 1").unwrap();
+        b = BoardState::from_fen("6rk/1b4np/5pp1/1p6/8/1P3NP1/1B3P1P/5RK1 w Kq - 0 1").unwrap();
         assert!(!b.black_king_side_castle);
         assert!(b.black_queen_side_castle);
         assert!(b.white_king_side_castle);
@@ -584,40 +698,52 @@ mod tests {
 
     #[test]
     fn random_pos() {
-        let b = board_from_fen("4R1B1/1kp5/1B1Q4/1P5p/1p2p1pK/8/3pP3/4N1b1 w - - 0 1").unwrap();
-        assert_eq!(b.board[2][6], WHITE | ROOK);
-        assert_eq!(b.board[2][8], WHITE | BISHOP);
-        assert_eq!(b.board[3][3], BLACK | KING);
-        assert_eq!(b.board[3][4], BLACK | PAWN);
-        assert_eq!(b.board[4][3], WHITE | BISHOP);
-        assert_eq!(b.board[4][5], WHITE | QUEEN);
-        assert_eq!(b.board[5][3], WHITE | PAWN);
-        assert_eq!(b.board[5][9], BLACK | PAWN);
-        assert_eq!(b.board[6][3], BLACK | PAWN);
-        assert_eq!(b.board[6][6], BLACK | PAWN);
-        assert_eq!(b.board[6][8], BLACK | PAWN);
-        assert_eq!(b.board[6][9], WHITE | KING);
-        assert_eq!(b.board[8][5], BLACK | PAWN);
-        assert_eq!(b.board[8][6], WHITE | PAWN);
-        assert_eq!(b.board[9][6], WHITE | KNIGHT);
-        assert_eq!(b.board[9][8], BLACK | BISHOP);
+        let b =
+            BoardState::from_fen("4R1B1/1kp5/1B1Q4/1P5p/1p2p1pK/8/3pP3/4N1b1 w - - 0 1").unwrap();
+        assert_eq!(b.board[2][6], Square::from(Piece::rook(White)));
+        assert_eq!(b.board[2][8], Square::from(Piece::bishop(White)));
+        assert_eq!(b.board[3][3], Square::from(Piece::king(Black)));
+        assert_eq!(b.board[3][4], Square::from(Piece::pawn(Black)));
+        assert_eq!(b.board[4][3], Square::from(Piece::bishop(White)));
+        assert_eq!(b.board[4][5], Square::from(Piece::queen(White)));
+        assert_eq!(b.board[5][3], Square::from(Piece::pawn(White)));
+        assert_eq!(b.board[5][9], Square::from(Piece::pawn(Black)));
+        assert_eq!(b.board[6][3], Square::from(Piece::pawn(Black)));
+        assert_eq!(b.board[6][6], Square::from(Piece::pawn(Black)));
+        assert_eq!(b.board[6][8], Square::from(Piece::pawn(Black)));
+        assert_eq!(b.board[6][9], Square::from(Piece::king(White)));
+        assert_eq!(b.board[8][5], Square::from(Piece::pawn(Black)));
+        assert_eq!(b.board[8][6], Square::from(Piece::pawn(White)));
+        assert_eq!(b.board[9][6], Square::from(Piece::knight(White)));
+        assert_eq!(b.board[9][8], Square::from(Piece::bishop(Black)));
     }
 
     #[test]
     #[should_panic]
     fn bad_fen_string() {
-        board_from_fen("this isn't a fen string").unwrap();
+        BoardState::from_fen("this isn't a fen string").unwrap();
     }
 
     #[test]
     #[should_panic]
     fn bad_fen_string_bad_char() {
-        board_from_fen("rnbqkbnH/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
+        BoardState::from_fen("rnbqkbnH/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
     }
 
     #[test]
     #[should_panic]
     fn bad_fen_string_too_many_chars() {
-        board_from_fen("rnbqkbnrrrrr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
+        BoardState::from_fen("rnbqkbnrrrrr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+            .unwrap();
+    }
+
+    #[test]
+    fn right_values() {
+        assert_eq!(Pawn.value(), 100);
+        assert_eq!(Knight.value(), 320);
+        assert_eq!(Bishop.value(), 330);
+        assert_eq!(Rook.value(), 500);
+        assert_eq!(Queen.value(), 900);
+        assert_eq!(King.value(), 20000);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
     };
 
     let fen = matches.value_of("fen").unwrap_or(board::DEFAULT_FEN_STRING);
-    let board = match board::board_from_fen(fen) {
+    let board = match board::BoardState::from_fen(fen) {
         Ok(b) => b,
         Err(err) => {
             println!("{}", err);


### PR DESCRIPTION
This replaces the existing bitwise arithmetic with structures and many
of the top-level board functions with type methods.

There is no change to the chess logic here -- this is just a refactor.

I won't be hurt if you don't want to merge this!  The refactor was a nice way for me to understand the code, and IMHO makes it more "idiomatic".